### PR TITLE
fix: Swap function used in displayImportedRouteCard() to provide accurate ETAs

### DIFF
--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -1,4 +1,4 @@
-import { showError, addClickListener, createRouteCard, calculateEta, formatDistance } from "./utils.js";
+import { showError, addClickListener, createRouteCard, calculateEta, formatDistance, formatETA } from "./utils.js";
 
 const allRoutesContainer = document.getElementById("all-routes-container");
 
@@ -39,7 +39,7 @@ export function displayImportedRouteCard(data) {
     "year": "2-digit"
     }).format(today);
 
-    const formattedETA = calculateEta(routeInfo.etaSeconds)
+    const formattedETA = formatETA(routeInfo.etaSeconds);
 
     const routeCard = createRouteCard(routeInfo.routeName, formattedToday, routeInfo.distanceKm, formattedETA, routeInfo.elevationGainMetres);
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -341,6 +341,7 @@ export function  closeImportRoute() {
 async function handleRouteImport() {
   const selectedInputType = whichInputTypeSelected();
   let routeName;
+  let data; // this will store the return value of the flask route 'import_route_file', it is initialised first as if done so in the try statement then the next try statement cannot use it
 
   if (selectedInputType === "file") {
 
@@ -357,7 +358,7 @@ async function handleRouteImport() {
         return false;
       }
 
-      const data = await processImportedRouteFile(file); 
+      data = await processImportedRouteFile(file); 
 
       if (!data || !data.coords) {
         showError("Could not parse coordinates from file.");

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -95,8 +95,11 @@ export function calculateEta(distanceKm) {
   const etaMinutesRemainder = etaMinutes % 60;
 
   if (etaHoursInt > 0) {
+    console.log(`DEBUG: ETA CALCULATED IS ${etaHoursInt} + ${etaMinutes}`)
     return `${etaHoursInt}h ${etaMinutesRemainder}m`;
   }
+
+  console.log(`DEBUG: ETA CALCULATED IS ${etaHoursInt} + ${etaMinutes}`)
   return `${etaMinutesRemainder}m`;
 }
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>Register</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/register_page.css')}}">
+    <link rel="stylesheet" href="static/css/styles.css" />
+    <link rel="stylesheet" href="static/css/register_page.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="icon" href="static/Crest-Logo.png">
 </head>


### PR DESCRIPTION
# Fix

- This PR fixes issue #5 

## Details

- The wrong utility function was being used to display the route card of the imported route 
- The wrong function used was calculateETA(distanceKm)
- This function is used whilst saving routes to normalise route information
- The specific line that was the issue is `const formattedETA = calculateETA(routeInfo.eta_seconds)`
- As can be seen, seconds were passed into the function instead of the distance of the route (which would have provided the correct output) 
- To fix this, the formatETA(seconds) function was used instead leaving the error-causing line to become: `const formattedETA = formatETA(routeInfo.eta_seconds)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route import so parsed route details are preserved and saved correctly.
  * Updated route ETA display to use a more consistent formatted time label.
  * Fixed stylesheet loading on the registration page to ensure styling is applied reliably.

* **Chores**
  * Added extra logging around ETA calculations for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->