### PR TITLE
feat: Add pgadmin service to docker-compose.yml to allow for easier observation of data 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:15
+    image: postgres:16-alpine
     env_file:
       - path: example.env
         required: true
@@ -44,6 +44,23 @@ services:
     depends_on:
       db:
         condition: service_healthy
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: crestr-pgadmin
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASS}
+      PGADMIN_CONFIG_SERVER_MODE: '${PGADMIN_SERVER_MODE}'
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: '${PGADMIN_MASTER_REQ}'
+    ports:
+      - "${PGADMIN_PORT}:80"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   postgres_data:
+  pgadmin_data:


### PR DESCRIPTION
# Description 

## What was added

- Added a `pgadmin` service to `docker-compose.yml`
- configured it to run alongside the existing `db` service
- exposed it on the `5050` port 

## Why

- Makes it much easier to complete queries, modify data, and look for changes in data (such as errors in how data is stored)
- Removes the need for the local installation of pgAdmin (especially important for anyone wishing to host this on a small device such as a raspberry pi) / exclusive use of command line tools (which struggle with length coordinate data)
- Aligns more closely to production-grade practices

## How to use
- run: 
  - `docker-compose down`
  - `docker-compose up -d`
- Access the pgAdmin site at `localhost:5050`
- Enter Postgres credentials as set in your env file or if you have not set credentials see example.env to view your values 

## Notes
- Postgres image was updated to `postgres:16-alpine` for a slimmer build 
- The pgAdmin service has no affect on the `web` or `db` services