### PR TITLE
fix: Amend the save route panel; resolve broken chevron icon and fix width

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -482,7 +482,7 @@ body {
 }
 
 #save-route-toggle-button svg {
-    transition: all .2s ease-in-out;
+    transition: transform .2s ease-in-out;
 }
 
 #save-route-toggle-button.opened svg {
@@ -502,7 +502,7 @@ body {
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-radius: 0 0 8px 8px;
-    border: none;
+    border: 1px solid transparent;
     border-top: none;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     width: 15rem;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -457,7 +457,7 @@ body {
     z-index: 1000;
     position: absolute;
     right: 12rem;
-    width: 9rem;
+    width: 15rem;
     display: flex;
     flex-direction: column; /* to stack button + panel */
 }
@@ -478,14 +478,14 @@ body {
     font-size: 14px;
     cursor: pointer;
     gap: 6px;
-    transition: all 0.1s ease-in-out;
+    transition: all 0.15s ease-in-out;
 }
 
-#save-route-toggle-button i {
-    transition: transform 0.25s ease;
+#save-route-toggle-button svg {
+    transition: all .2s ease-in-out;
 }
 
-#save-route-toggle-button.opened i {
+#save-route-toggle-button.opened svg {
     transform: rotate(180deg);
 }
 
@@ -505,18 +505,18 @@ body {
     border: none;
     border-top: none;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    width: 9rem;
-    transition: height 0.1s ease-in-out;
+    width: 15rem;
+    transition: all 0.15s ease-in-out;
 }
 
 #save-route-toggle-button:hover {
-    background: rgb(255 255 255 / 0.75);
+    background: rgba(223, 221, 221, 0.65);
     border-color: #cbd5e1;
-    transform: scale(1.03);
 }
 
-#save-route-toggle-button:active {
-    transform: scale(1);
+#save-route-toggle-button:hover + #save-route {
+    background: rgba(223, 221, 221, 0.65);
+    border-color: #cbd5e1;
 }
 
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -381,7 +381,7 @@ export function updateSaveRouteContainer() {
   const isOpen = saveRouteToggleButton.classList.toggle("opened");
 
     if (isOpen) {
-        saveRouteDiv.style.height = "12.625rem";
+        saveRouteDiv.style.height = `${saveRouteDiv.scrollHeight}px`;
     } else {
         saveRouteDiv.style.height = "0px";
     }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -113,7 +113,7 @@ const navBar = document.getElementById("the-sidenav");
 const autoModeContent = document.getElementById("auto-mode-content");
 const manualModeContent = document.getElementById("manual-mode-content");
 
-// saved route div + saving routes
+// saved route div 
 const saveRouteDiv = document.getElementById("save-route");
 const routeNameEntry = document.getElementById("route-name");
 const saveContainer = document.getElementById('save-route-container');
@@ -375,6 +375,16 @@ function openImportRoute() {
 
 export function  closeImportRoute() {
   importRoutePanel.style.width = "0";
+};
+
+export function updateSaveRouteContainer() {
+  const isOpen = saveRouteToggleButton.classList.toggle("opened");
+
+    if (isOpen) {
+        saveRouteDiv.style.height = "12.625rem";
+    } else {
+        saveRouteDiv.style.height = "0px";
+    }
 };
 
 //#endregion
@@ -1097,16 +1107,6 @@ function redoManualRoutePoint() {
   if (!restoredPoint) return;
 
   addManualPoint(restoredPoint[0], restoredPoint[1]);
-};
-
-export function updateSaveRouteContainer() {
-  const isOpen = saveRouteToggleButton.classList.toggle("opened");
-
-    if (isOpen) {
-        saveRouteDiv.style.height = "12.625rem";
-    } else {
-        saveRouteDiv.style.height = "0px";
-    }
 };
 
 function closeSaveRouteContainer() {

--- a/templates/map.html
+++ b/templates/map.html
@@ -104,7 +104,7 @@
 
                 <!-- toggle button -->
                 <button id="save-route-toggle-button" class="closed">
-                    <i data-lucide="chevron-down"></i>
+                    <i id="save-route-div-icon" data-lucide="chevron-down"></i>
                     <span>Save Route</span>
                     <span></span>
                 </button>

--- a/templates/map.html
+++ b/templates/map.html
@@ -104,7 +104,7 @@
 
                 <!-- toggle button -->
                 <button id="save-route-toggle-button" class="closed">
-                    <i id="save-route-div-icon" data-lucide="chevron-down"></i>
+                    <i data-lucide="chevron-down"></i>
                     <span>Save Route</span>
                     <span></span>
                 </button>


### PR DESCRIPTION
# Description 

This PR edits the save route panel so that the chevron icon now works correctly, as well as ensuring that the panel is of the right width and height. UX has also been improved by replacing the use of `scale()` with a change in `background` in the CSS associated with the save route panel. 

# Changes

- Save route panel width changed from `9rem` to `15rem` so that the entire content of the save route panel could be seen
- Chevron icon fixed by swapping the `i` selector with `svg` instead (as Lucide changes the <i> icon element to an `svg` element at runtime) ensuring that the icon correctly rotates upon the opening and closing of the panel
- Replaced the use of `scale()` with a change in `background-color` instead, allowing for better UI design as the use of `scale()` meant that the dropdown button was offset from the rest of the save route panel. 