### PR TITLE
fix: Resolved wrong distance units on elevation profile chart upon changing distance units in settings

### DIFF
--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -73,8 +73,8 @@ export function createElevationProfile(coordinates) {
     const fill = isDark ? "rgba(37,99,235,0.25)" : "rgba(37,99,235,0.15)";
 
     // distance unit strings
-    const distanceLabel = getDistanceUnit() === "km" ? "Distance (km)" : "Distance (miles)";
-    const distanceExtension = getDistanceUnit() === "km" ? " km" : " miles";
+    const distanceLabel = distanceUnit === "km" ? "Distance (km)" : "Distance (miles)";
+    const distanceExtension = distanceUnit === "km" ? " km" : " miles";
 
 
 

--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -1,7 +1,7 @@
 import { getDistance } from 'https://cdn.jsdelivr.net/npm/ol@v10.3.1/sphere.js';
 import { toLonLat } from 'https://cdn.jsdelivr.net/npm/ol@v10.3.1/proj.js';
 import { normaliseCoordLength } from './routes/routeState.js';
-import { getTheme } from './settingsState.js';
+import { getTheme, getDistanceUnit } from './settingsState.js';
 
 let elevationChart = null;
 let currentCoordinates = null;
@@ -38,6 +38,7 @@ export function createElevationProfile(coordinates) {
     chartData.push({ x: 0, y: geoCoordinates[0][2] });
 
     let cumulativeDistance = 0;
+    const distanceUnit = getDistanceUnit();
 
     for (let i = 1; i < geoCoordinates.length; i++) {
         const p1 = geoCoordinates[i-1];
@@ -47,10 +48,15 @@ export function createElevationProfile(coordinates) {
         const segmentMeters = getDistance([p1[0], p1[1]], [p2[0], p2[1]]);
         const segmentKm = segmentMeters / 1000;
 
-        cumulativeDistance += segmentKm;
+        if (distanceUnit == "km") {
+            cumulativeDistance += segmentKm;
+        }
+        else if (distanceUnit == "miles") {
+            cumulativeDistance += (segmentKm * 0.621371);
+        }
 
         chartData.push({
-            x: parseFloat(cumulativeDistance.toFixed(2)),
+            x: Math.round(cumulativeDistance * 100) / 100, // Math.round only rounds to integer, so we multiply by 100 and then divide by 100 to get value 2dp 
             y: p2[2]
         });
     }  
@@ -65,6 +71,10 @@ export function createElevationProfile(coordinates) {
     const grid = isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)";
     const border = isDark ? "#2563eb" : "#1d4ed8";
     const fill = isDark ? "rgba(37,99,235,0.25)" : "rgba(37,99,235,0.15)";
+
+    // distance unit strings
+    const distanceLabel = getDistanceUnit() === "km" ? "Distance (km)" : "Distance (miles)";
+    const distanceExtension = getDistanceUnit() === "km" ? " km" : " miles";
 
 
 
@@ -93,7 +103,7 @@ export function createElevationProfile(coordinates) {
                 legend: { display: false },
                 tooltip: {
                     callbacks: {
-                        title: (ctx) => ctx[0].raw.x + " km",
+                        title: (ctx) => ctx[0].raw.x + distanceExtension,
                         label: (ctx) => `${ctx.raw.y} m`
                     }
                 }
@@ -103,7 +113,7 @@ export function createElevationProfile(coordinates) {
                     type: 'linear',
                     title: { 
                         display: true, 
-                        text: 'Distance (km)', 
+                        text: distanceLabel, 
                         color: text,
                         font: { size: 13 }
                     },

--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -48,11 +48,10 @@ export function createElevationProfile(coordinates) {
         const segmentMeters = getDistance([p1[0], p1[1]], [p2[0], p2[1]]);
         const segmentKm = segmentMeters / 1000;
 
-        if (distanceUnit == "km") {
-            cumulativeDistance += segmentKm;
-        }
-        else if (distanceUnit == "miles") {
-            cumulativeDistance += (segmentKm * 0.621371);
+        if (distanceUnit === "miles") {
+            cumulativeDistance += segmentKm * 0.621371;
+        } else {
+            cumulativeDistance += segmentKm; // default: km
         }
 
         chartData.push({

--- a/static/js/settingsState.js
+++ b/static/js/settingsState.js
@@ -147,3 +147,11 @@ export function getTheme() {
   }
   return currentTheme
 } 
+
+/**
+ * returns the correct distance at the time of calling 
+ * @returns {string} # a string of the distance unit which is either km or miles  
+ */
+export function getDistanceUnit() {
+  return appSettings.distanceUnit;
+}

--- a/static/js/settingsState.js
+++ b/static/js/settingsState.js
@@ -149,8 +149,8 @@ export function getTheme() {
 } 
 
 /**
- * returns the correct distance at the time of calling 
- * @returns {string} # a string of the distance unit which is either km or miles  
+ * Returns the current distance unit preference.
+ * @returns {'km' | 'miles'}
  */
 export function getDistanceUnit() {
   return appSettings.distanceUnit;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1291,7 +1291,13 @@ function handleDistanceUnitToggle() {
     displayLoadedRouteStats(getLastLoadedRouteStats());
   }
   initChartToggleListener();
-  createElevationProfile();
+
+  const coords =
+    manualRouteState.pathCoords.length > 1
+      ? manualRouteState.pathCoords
+      : (getCurrentPathData() || getLoadedRouteCoordinates());
+
+  if (coords && coords.length > 1) createElevationProfile(coords);
 };
 
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1290,6 +1290,8 @@ function handleDistanceUnitToggle() {
   else if (getLastLoadedRouteStats) {
     displayLoadedRouteStats(getLastLoadedRouteStats());
   }
+  initChartToggleListener();
+  createElevationProfile();
 };
 
 


### PR DESCRIPTION
# Summary 

This PR aims to improve UX as well as resolve a critical error before the beta launch (set for next week) by solving two issues within the elevation profile chart. These are **the x axis and the data values of the chart** and the **visibility of the chart**. The chart became invisible when changing settings whilst a route was shown. As well as this, even when changing settings, the actual chart showed incorrect data values, showing kilometres rather than metres. 

# Changes

- Called the `initChartToggleListener()` and `createElevationProfile()` functions upon the changing of the distance units in `ui.js`, this makes the elevation profile chart become visible even when changing settings by rebuilding the chart
- Added conditional logic in `elevationChart.js` to ensure that the data values and X axis are correct depending on the settings
- Added a `getDistanceUnit()` utility function in `settingsState.js` 

The above changes solve all issues (currently known) with the elevation profile. 