### PR TITLE
chore: Add dev variables and commands (commented out) in docker-compo…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       - postgres_data:/var/lib/postgresql/data
   web:
     build: .
-    command: gunicorn -c src/gunicorn.config.py src.app:app
+    command: gunicorn -c src/gunicorn.config.py src.app:app ### Use this command for prod 
+    ### command: flask run --host=0.0.0.0 --port=5000 --debug ### Use this command for dev logs --> easier debugging + more info on errors
     volumes:
       # this mounts the entire src (backend python flask / FastAPI) folder
       - ./src:/app/src
@@ -33,6 +34,12 @@ services:
       - GUNICORN_WORKERS=2 
       - GUNICORN_LOG_LEVEL=info
       - PYTHONPATH=/app/src
+
+      ### DEBUGGING ENVIRONMENT VARIABLES ###
+      # Uncomment the lines below for local development debugging
+      - FLASK_DEBUG=1
+      - LOAD_GRAPH_ON_IMPORT=0    # 0 stops graph loading on import for fast hot-reloads
+      - FLASK_ENV=development
     ports:
       - "5000:5000"
     env_file:


### PR DESCRIPTION
# Summary

This PR updates the Docker configuration to introduce commented-out development environments, commands, and environment variables.

# Why

Currently, the configuration defaults strictly to production settings (e.g., using Gunicorn and optimised production flags). While ideal for deployment, this makes local troubleshooting cumbersome. By providing pre-configured but commented-out development alternatives (like the Flask development server and hot-reload optimisation flags), developers can easily toggle between production testing and rapid local debugging without having to look up or rewrite the necessary configurations.

# Changes

- **Added Dev Command Alternative:** Added a commented-out flask run command in the web service to allow for easier logs and error debugging during local development.
- **Added Debugging Environment Variables:** Included commented-out environment variables (`FLASK_DEBUG`, `LOAD_GRAPH_ON_IMPORT`, and `FLASK_ENV`) to streamline local setup and enable fast hot-reloads.
- **Preserved Production Defaults:** Kept the active configurations set to production mode (`gunicorn`) so that deployments remain unaffected.