### PR TITLE
fix: Add dynamic displaying of no route message upon delete route if …

### DIFF
--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -8,7 +8,7 @@ import { closeNav, closeSavedRoutesDash,  } from "../ui.js"
 import { displayLoadedRouteOnMap } from "./loadRoute.js";
 import { setLoadedRouteCoordinates, setCurrentPathData } from "./routeState.js";
 import { createElevationProfile, initChartToggleListener } from "../elevationChart.js";
-import {addClickListener} from "../utils.js"
+import {addClickListener, createNoRouteCard} from "../utils.js"
 
 const allRoutesContainer = document.getElementById("all-routes-container");
 
@@ -67,7 +67,14 @@ async function onDeleteClick(event) {
   try {
     const response = await deleteRoute(route.routeName);
     if (response.success) {
-     routeCard.remove();
+      routeCard.remove();
+
+      const remainingCards = document.querySelectorAll('.route-card');
+
+      if (remainingCards.length === 0) {
+        allRoutesContainer.insertAdjacentHTML('beforeend', createNoRouteCard());
+      }
+
     }
   } catch (error) {
     console.error("Delete route failed:", error);
@@ -85,7 +92,6 @@ async function onDeleteClick(event) {
  */
 async function onDownloadClick(event, format, DOMElement) {
 
-  const temp = DOMElement.innerHTML
   DOMElement.classList.add('loading')
   DOMElement.disabled = true;
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -229,3 +229,22 @@ export function createRouteCard(routeName, formattedDate, distanceInKm, ETA, ele
                           </div>
                           `;
 }
+
+/**
+ * This returns a card showing users that there are no saved routes for both a clean UI and a UX
+ * 
+ * @returns {string} HTML string for the route card showing that there are no routes 
+ */
+export function createNoRouteCard() {
+  return `<div id="no-routes-wrapper" class="no-routes-wrapper">
+              <div class="no-routes-card">
+                  <h2 class="no-routes-title">No routes saved yet</h2>
+                  <p class="no-routes-description">
+                      You haven’t created any routes. Start planning your next adventure below.
+                  </p>
+                  <button id="no-route-create-button" class="no-routes-create-btn generate-button">
+                      Create a route
+                  </button>
+              </div>
+          </div>`
+}


### PR DESCRIPTION
# Summary

This PR fixes the logic for detecting when all route cards have been Deleted. Now, a message is shown to users if they no longer have any routes, immediately rather than only after a refresh

# Changes
- **Instant UI Update:** Fixed the bug where the "No Routes" message would only appear after a page refresh by triggering the DOM check immediately after a card is deleted.
- **Card Removal Logic:** Ensured the specific routeCard is removed from the DOM dynamically before verifying the remaining card count.