### PR TITLE
chore: standardise route card values

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -195,12 +195,33 @@ def is_beta_code_validated():
     else:
         return True
 
+@app.template_filter('format_elevation')
+def format_elevation(elevation_gain):
+    if not isinstance(elevation_gain, int) or isinstance(elevation_gain, float):
+        elevation_gain = float(elevation_gain)
+
+    if elevation_gain >= 0:
+        return f"+{elevation_gain}"
+    else:
+        return f"{elevation_gain}"
+
+@app.template_filter('format_eta')
+def format_eta(seconds):
+    hours = math.floor(seconds / 3600)
+    minutes = math.floor((seconds % 3600) / 60)
+
+    if hours == 0:
+        return f"{minutes}m"
+    else:
+        return f"{hours}h {minutes}m"
+    
 # STRFTIME FILTER
 @app.template_filter("strftime")
 def strftime_filter(date, format: str):
     if isinstance(date, str):
         date = datetime.isoformat(date)
     return date.strftime(format)
+
 
 #region ERROR HANDLER RENDER_TEMPLATES()
 
@@ -663,17 +684,6 @@ if os.getenv("LOAD_GRAPH_ON_IMPORT", "1").lower() not in ("0", "false", "no"):
 
 # Create once at module level
 transformer = Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True)
-
-def format_eta(seconds):
-    hours = math.floor(seconds / 3600)
-    minutes = math.floor((seconds % 3600) / 60)
-
-    if hours == 0:
-        return f"{minutes}m"
-    else:
-        return f"{hours}h {minutes}m"
-    
-app.jinja_env.filters['format_eta'] = format_eta
 
 
 def haversine(x1, y1, x2, y2):

--- a/templates/map.html
+++ b/templates/map.html
@@ -218,7 +218,7 @@
                     <div class="route-card" data-route-name="{{ route.name }}">
                         <div class="route-card-header">
                             <h3 class="route-card-name">{{ route.name }}</h3>
-                            <span class="route-card-date">Saved on {{ route.created_at | strftime("%d/%m/%y") }}</span>
+                            <span class="route-card-date">Saved on {{ route.created_at | strftime("%d/%m/%Y") }}</span>
                         </div>
                         <div class="route-card-stats">
                             <div class="stat-item">
@@ -227,11 +227,11 @@
                             </div>
                             <div class="stat-item">
                                 <span class="stat-label">ETA:</span>
-                                <span class="stat-value">{{ route.eta_seconds | format_eta}}</span>
+                                <span class="stat-value">{{ route.eta_seconds | format_eta }}</span>
                             </div>
                             <div class="stat-item">
                                 <span class="stat-label">Elevation Change:</span>
-                                <span class="stat-value">{{ route.elevation_change }}</span>
+                                <span class="stat-value">{{ route.elevation_change | format_elevation }}</span>
                             </div>
                         </div>
                         <div class="route-card-actions">


### PR DESCRIPTION
# PR: Standardise route card values

## Summary

This PR aims to standardise route card values within the saved route dashboard between the frontend's dynamically placed route cards and the backend's generated route cards upon refresh. The main issue this PR solves is consistency between the UI in the saved routes dashboard, meaning the PR improves UI/UX. 

## Changes

- Added a `format_elevation()` function in the python backend as a `template_filter`: This means that all elevation values are passed into the function returning a formatted string to display
- Changed the input into the `strftime_filter()` function to `%d%m%Y` instead of `%d%m%y` so that a 4-digit year is shown (showing the century), to provide better information to users as well as to provide consistency as this is already done on the dynamically inserted route cards in the frontend 