### PR TITLE
Chore/transition to elev gain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,13 @@ RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 # this installs pg_isready so the entrypoint can wait for postgres
+# it also installs curl (to be used when getting the graph)
 # no install recommends is used to keep the layer small
 RUN apt-get update \
- && apt-get install -y --no-install-recommends postgresql-client \
+ && apt-get install -y --no-install-recommends postgresql-client curl \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /app/Pathfinding
-
-COPY Pathfinding/better_path_graph.pkl /app/Pathfinding/better_path_graph.pkl
 
 # this copies python backend 
 COPY src/ /app/src/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,5 +14,19 @@ done
 echo "PostgreSQL is ready. Running the database migration..."
 alembic upgrade heads
 
+GRAPH_PATH="/app/Pathfinding/better_path_graph.pkl"
+
+if [ ! -f "$GRAPH_PATH" ]; then
+    echo "Pathfinding graph ($GRAPH_PATH) is missing, downloading from github releases..."
+
+    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.1.0/graph.pkl"
+
+    echo "Pathfinding graph downloaded"
+else
+    echo "Pathfinding graph found locally"
+fi
+
+
+
 echo "Starting application..."
 exec "$@"

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,6 @@
 # These imports are for pathfinding.
 from pathfinder import (
     a_star,
-    snap_to_largest_component,
     build_global_kdtree,
 )
 
@@ -38,7 +37,7 @@ import time
 import io
 
 # These imports are for date and time handling.
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 
 # These imports are for geospatial processing.
 from pyproj import Transformer
@@ -226,15 +225,15 @@ def strftime_filter(date, format: str):
 #region ERROR HANDLER RENDER_TEMPLATES()
 
 @app.errorhandler(404)
-def page_not_found(error):
+def page_error_404(error):
     return render_template('Error-Pages/404.html')
 
 @app.errorhandler(405)
-def page_not_found(error):
+def page_error_405(error):
     return render_template('Error-Pages/405.html')
 
 @app.errorhandler(500)
-def page_not_found(error):
+def page_error_500(error):
     return render_template('Error-Pages/500.html')
 
 #endregion
@@ -376,8 +375,6 @@ def registering():
 @app.route("/delete_account", methods=["POST"])
 @limiter.limit("10 per minute")
 def delete_account():
-    username = session.get('username')
-
     with Session(engine) as db:
 
        
@@ -779,7 +776,7 @@ def parse_elevation(elevation_string: str):
         return None
     try:
         return float(elevation_string.replace('m', '').strip())
-    except:
+    except Exception:
         return None
 
 # helper function used in creation of gpx / geojson files which converts hrs and minutes to seconds 
@@ -794,7 +791,7 @@ def parse_eta_to_seconds(eta_string: str):
             minutes_part = eta_string.split('h')[-1] if 'h' in eta_string else eta_string
             minutes = int(minutes_part.replace('m', '').strip())
         return hours * 3600 + minutes * 60
-    except:
+    except Exception:
         return None
 
 #region GEOSPATIAL FILE PROCESSING HELPER FUNCTIONS
@@ -1051,6 +1048,23 @@ def calculate_path():
             web_mercator_coordinates.append([x, y, elev])
         else:
             web_mercator_coordinates.append([x, y])
+
+    elevation_gain = 0
+    elevation_change = 0
+    
+    # this calculates the elevation GAIN
+    for node1, node2 in zip(path, path[1:]):
+        elev1 = graph.nodes.get(node1, {}).get('elev')
+        elev2 = graph.nodes.get(node2, {}).get('elev')
+
+        if elev1 is not None and elev2 is not None:
+            elevation_gain += max(0, elev2 - elev1)
+
+    # this calculates the elevation CHANGE
+    start_elevation = int(graph.nodes[start_node]['elev'])
+    end_elevation = int(graph.nodes[end_node]['elev'])
+
+    elevation_change = end_elevation - start_elevation
     
     start_coords = web_mercator_coordinates[0]
     end_coords = web_mercator_coordinates[-1]
@@ -1075,16 +1089,11 @@ def calculate_path():
     # Calculates optimal map centre and zoom
     map_centre, map_zoom = service.calculate_map_center_and_zoom(web_mercator_coordinates)
 
-    start_elevation = int(graph.nodes[start_node]['elev'])
-    end_elevation = int(graph.nodes[end_node]['elev'])
-
-    elevation_difference = end_elevation - start_elevation
-    elevation_change = f"+{elevation_difference}m" if elevation_difference >= 0 else f"{elevation_difference}m" 
-
     route_stats = {
         "start_elevation": start_elevation,
         "end_elevation": end_elevation,
         "elevation_change": elevation_change,
+        "elevation_gain": elevation_gain, 
         "total_distance": round(total_distance_km, 2),
         "eta_seconds": eta_seconds
     }
@@ -1426,9 +1435,7 @@ def import_route():
 
     if not uploaded_file:
 
-        with Session(engine) as db:
-
-            log_action('Importing Route', False, 'Uploaded file could not be retrieved', None, 'IMPORT_ROUTE')
+        log_action('Importing Route', False, 'Uploaded file could not be retrieved', None, 'IMPORT_ROUTE')
 
         return jsonify({"success": False, "message": "Cannot receive uploaded file"}), 400
     
@@ -1499,7 +1506,7 @@ def import_route():
 
         # this handles KML file types
         elif ext == "kml":
-            uploaded_file.stream.seek(0);
+            uploaded_file.stream.seek(0)
             doc = KML.parse(uploaded_file.stream, strict=False)
             coords = extract_kml_coords(doc)
             return jsonify({"success": True, "coords": coords})
@@ -1546,7 +1553,7 @@ def import_route():
                 if geo.get('type') in ["Point", "LineString", "MultiLineString", "Polygon"]:
                     geometries.append(geo)
                 else:
-                    log_action('Importing Route', False, 'Invalid GeoJSON Structure', None, "IMPORT_ROUTE");
+                    log_action('Importing Route', False, 'Invalid GeoJSON Structure', None, "IMPORT_ROUTE")
                     return jsonify({"success": False, "message": "There was an error on our end, please try again later."})
 
             # this is for processing LineString geometries
@@ -1743,7 +1750,7 @@ def map_view():
                         "name": point.name,
                         "coordinates": [web_mercator_x, web_mercator_y]
                     })
-                except Exception as e:
+                except Exception:
                     continue
             
             return render_template("map.html",
@@ -1802,7 +1809,7 @@ def search_area():
             })
         else:
             return jsonify({"success": False, "message": "Could not find area"})
-    except Exception as error:
+    except Exception:
         log_action('Searching for Area', False, traceback.format_exc(), None, 'SEARCH_AREA')
 
 

--- a/static/js/routes/routeState.js
+++ b/static/js/routes/routeState.js
@@ -129,37 +129,44 @@ export function extractElevationProfile(coords) {
  * @returns The range of elevation of a path in the form { min: min_elevation, max: max_elevation }
  */
 export function getElevationRange(coords) {
-  return coords.reduce((range, coord) => {
-    if (coord.length === 3) {
-      const elevation = coord[2];
+  if (!coords || coords.length === 0) return { min: null, max: null };
 
-      if (range.min === null || elevation < range.min) range.min = elevation;
-      if (range.max === null || elevation > range.max) range.max = elevation;
-    }
-    return range;
-  }, { min: null, max: null})
+  // this extracts the elevation values of each coordinate
+  const elevations = coords
+    .filter(coord => coord && coord.length === 3)
+    .map(coord => coord[2]);
+
+  // this returns null values if no elevation data is present
+  if (elevations.length === 0) return { min: null, max: null };
+
+  // this uses the spread operator to find min and max values instantly
+  return {
+    min: Math.min(...elevations),
+    max: Math.max(...elevations)
+  };
 }
 
 /**
- * 
- * @param {Array} coords 
- * @returns The elevation change that the hiker would climb 
+ * @param {Array} coords - Array of [long, lat, elev] arrays
+ * @returns {number} The total elevation gain 
 */
-export function calculateElevationChange(coords) {
+export function calculateElevationGain(coords) {
   if (!coords || coords.length < 2) return 0;
 
-  let totalChange = 0;
+  let totalGain = 0;
 
   for (let i = 1; i < coords.length; i++) {
     const prev = coords[i - 1];
     const curr = coords[i];
 
     if (prev.length === 3 && curr.length === 3) {
-      totalChange += curr[2] - prev[2];
+      const elevationDifference = curr[2] - prev[2];
+      // Only add positive differences (uphill)
+      totalGain += Math.max(0, elevationDifference);
     }
   }
 
-  return totalChange;
+  return totalGain;
 }
 
 /**
@@ -187,7 +194,6 @@ export function normaliseCoordLength(coords) {
     const secondElev = normalisedCoords[1][2];
 
     if (firstElev === 0 && secondElev !== 0) { // check if the first coord element doesn't have elevation AND that there is second Elevation
-      console.log(`Copied elevation ${secondElev} to first point`); // for debugging
       normalisedCoords[0][2] = secondElev;
     }
   }

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -104,11 +104,9 @@ export async function addManualPoint(x, y) {
   try {
 
     if (segmentCache[key]) { // this checks if the segment already exists in cache 
-      console.log("DEBUG: Found existing cache");
       segment = segmentCache[key];
     }
     else {
-      console.log("DEBUG: no existing cache found");
       const data = await getPathSegment(lastClickedPoint, finalClick);
 
       if (!data.success) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -12,7 +12,8 @@ import {
   addClickListener,
   formatETA,
   removeDOMElement,
-  createStatsPanel
+  createStatsPanel,
+  formatElevation
 } from "./utils.js";
 import { calculatePath, addManualPoint } from "./routing/routing.js";
 import {
@@ -57,7 +58,7 @@ import {
   extractElevation,
   extractElevationProfile,
   getElevationRange,
-  calculateElevationChange
+  calculateElevationGain
 } from "./routes/routeState.js";
 import {
   initCursorManager,
@@ -788,7 +789,7 @@ async function mapRenderComplete() {
   loadAndDisplaySavedPoints();  
 };
 
-//#region ROUTING
+//#region AUTOMATIC ROUTING
 
 async function handleAutoRouteGeneration(start=null, end=null) {
   const startPoint = start || startCoordEntry?.value || "";
@@ -896,8 +897,12 @@ function displayAutoRouteStats(routeStats) {
   statsDiv.id = "route-stats";
   document.body.appendChild(statsDiv);
 
-  statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), routeStats.eta_seconds, routeStats.elevation_change)
+  statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), routeStats.eta_seconds, formatElevation(routeStats.elevation_gain))
 };
+
+//#endregion
+
+//#region MANUAL ROUTING
 
 function checkIfCircularRoute() {
   const tolerance = 0.000001;
@@ -927,16 +932,6 @@ function removeExistingStats() {
   return true;
 };
 
-export function updateSavedRouteCards() {
-  const statValues = document.querySelectorAll('[data-distance-km]');
-  statValues.forEach(value => {
-    const rawKm = parseFloat(value.dataset.distanceKm);
-    if (isNaN(rawKm)) return;
-    const formattedValue = formatDistance(rawKm);
-    value.textContent = formattedValue;
-  });
-};
-
 export function updateManualRoute() {
   const map = getMap();
   if (!map) return;
@@ -952,13 +947,8 @@ export function updateManualRoute() {
   const etaDisplay = calculateEta(totalDistanceKm);
   const isSnappedToEnd = checkIfCircularRoute();
   const features = [];
-  let elevationDisplay = "N/A";
-  const range = getElevationRange(pathCoords);
-  if (range && typeof range.min === 'number' && typeof range.max === 'number') {
-    const change = range.max - range.min;
-    elevationDisplay = `${change >= 0 ? '+' : ''}${change}m`
-  }
-
+  const elevationGainDisplay = formatElevation(calculateElevationGain(pathCoords));
+  
   setLastKnownDistanceKm(totalDistanceKm);
 
   userClicks.forEach((point, index) => {
@@ -1004,10 +994,13 @@ export function updateManualRoute() {
 
   map.addLayer(manualRouteLayer);
 
-  updateManualRouteStats(distanceDisplay, etaDisplay, elevationDisplay, pathCoords);
+  const isOnePoint = pathCoords.length === 1;
+
+  updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords);
+  createElevationProfile(pathCoords);
 };
 
-function updateManualRouteStats(distanceDisplay, etaDisplay, elevationDisplay, pathCoords) {
+function updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords) {
   let statsDiv = document.getElementById("route-stats");
   let firstRender = !statsDiv
 
@@ -1017,25 +1010,22 @@ function updateManualRouteStats(distanceDisplay, etaDisplay, elevationDisplay, p
     statsDiv.id = "route-stats";
     document.body.appendChild(statsDiv);
 
-    statsDiv.innerHTML = createStatsPanel(distanceDisplay, etaDisplay, elevationDisplay);
+    statsDiv.innerHTML = createStatsPanel(distanceDisplay, etaDisplay, elevationGainDisplay);
 
     initChartToggleListener();   
   }
   else {
     document.getElementById("route-distance-display").textContent = distanceDisplay;
     document.getElementById("route-eta-display").textContent = etaDisplay;
-    document.getElementById("route-elevation-change-display").textContent = elevationDisplay;
+    document.getElementById("route-elevation-gain-display").textContent = elevationGainDisplay;
   }
 
   const toggleChartButton = document.getElementById('toggle-elevation-chart');
-  const isOnePoint = pathCoords.length === 1;
 
   if (toggleChartButton) {
     toggleChartButton.classList.toggle('one-point-only', isOnePoint);
     toggleChartButton.disabled = isOnePoint;
   }
-
-  createElevationProfile(pathCoords);
 }
 
 export function undoManualRoutePoint() {
@@ -1096,6 +1086,8 @@ function redoManualRoutePoint() {
   addManualPoint(restoredPoint[0], restoredPoint[1]);
 };
 
+//#endregion
+
 function closeSaveRouteContainer() {
   const isOpen = saveRouteToggleButton.classList.contains('opened')
 
@@ -1107,7 +1099,15 @@ function closeSaveRouteContainer() {
   return true;
 }
 
-//#endregion
+export function updateSavedRouteCards() {
+  const statValues = document.querySelectorAll('[data-distance-km]');
+  statValues.forEach(value => {
+    const rawKm = parseFloat(value.dataset.distanceKm);
+    if (isNaN(rawKm)) return;
+    const formattedValue = formatDistance(rawKm);
+    value.textContent = formattedValue;
+  });
+};
 
 //#region DRIVER.JS
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -95,11 +95,9 @@ export function calculateEta(distanceKm) {
   const etaMinutesRemainder = etaMinutes % 60;
 
   if (etaHoursInt > 0) {
-    console.log(`DEBUG: ETA CALCULATED IS ${etaHoursInt} + ${etaMinutes}`)
     return `${etaHoursInt}h ${etaMinutesRemainder}m`;
   }
 
-  console.log(`DEBUG: ETA CALCULATED IS ${etaHoursInt} + ${etaMinutes}`)
   return `${etaMinutesRemainder}m`;
 }
 
@@ -249,7 +247,7 @@ export function createNoRouteCard() {
           </div>`
 }
 
-export function createStatsPanel(distanceDisplay, etaDisplay, elevationDisplay) {
+export function createStatsPanel(distanceDisplay, etaDisplay, elevationGain) {
   return `
       <div class="stats-header">
           <span class="stats-title">Route Information</span>
@@ -267,7 +265,7 @@ export function createStatsPanel(distanceDisplay, etaDisplay, elevationDisplay) 
               </div>
               <div class="stat-row">
                   <span class="stat-label">Elevation Gain:</span>
-                  <span class="stat-value" id="route-elevation-change-display">${elevationDisplay}</span>
+                  <span class="stat-value" id="route-elevation-gain-display">${elevationGain}</span>
               </div>
           </div>
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -153,38 +153,6 @@
             </div>
         </dialog>
 
-        <!-- ##### ROUTE STATS PANEL ##### -->
-        {% if route_stats %}
-        <div id="route-stats">
-            <div class="stats-header">
-                <span class="stats-title">Route Information</span>
-                <button id="toggle-elevation-chart" class="stats-button">Elevation Profile</button>
-            </div>
-            <div id="stat-content-and-chart-container">
-                <div class="stats-content">
-                    <div class="stat-row">
-                        <span class="stat-label">Distance:</span>
-                        <span class="stat-value" id="route-distance-display">{{ route_stats.total_distance }}km</span>
-                    </div>
-                    <div class="stat-row">
-                        <span class="stat-label">ETA:</span>
-                        <span class="stat-value" id="route-eta-display">{{ route_stats.eta }}</span>
-                    </div>
-                    <div class="stat-row">
-                        <span class="stat-label">Elevation Change:</span>
-                        <span class="stat-value" id="route-elevation-change-display">{{ route_stats.elevation_change }}</span>
-                    </div>
-                </div>
-
-                <div> 
-                    <div id="elevation-chart-container">
-                        <canvas id="elevation-chart"></canvas>
-                    </div>
-                </div>
-            </div>
-        </div>
-        {% endif %}
-
 
         <div id="map"></div>
     </div>


### PR DESCRIPTION
# PR: Switch to Elevation Gain for Hiker Usability

## Summary

This PR replaces Elevation Change (Range) with Total Elevation Gain to improve data accuracy and hiker safety.

## Why This Matters

Our current metric only measures the net difference between the trail's highest and lowest points. This severely underreports the difficulty of trails that constantly fall and climb.

We are replacing this with a cumulative calculation that adds up every vertical metre climbed along the route, accurately capturing the true physical effort required.

## Key Benefits

- **Accurate Difficulty**: Reflects real physical exertion, preventing hikers from underestimating a trail.
- **Better Planning**: Allows hikers to accurately estimate travel times and avoid getting caught after dark.
- **Industry Standard**: Aligns our platform with major navigation apps.

## Core Changes

- **Backend**: Updated the pipeline to calculate cumulative gain and migrated existing trail data.
- **UI**: Updated all front-end labels to display "Elevation Gain."