### PR TITLE
fix: Resolve setting flask route endpoint + add <link> tag for custom…

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -29,6 +29,9 @@
     <!-- Error PopUp CSS File -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/error-toast.css') }}" />
 
+    <!-- Tours (custom driver.js) CSS file -->
+     <link rel="stylesheet" href="{{ url_for('static', filename='css/tours.css') }}">
+
     <!-- #endregion -->
 
     <!-- ICONS -->
@@ -488,8 +491,8 @@
             apiLoadRouteUrl: "{{ url_for('route_api.load_route') }}",
             mapPageUrl: "{{ url_for('map_view') }}",
             apiDownloadRouteUrl: "{{ url_for('route_api.download_route') }}",
-            apiSaveSettings: "{{ url_for('save_settings') }}",
-            apiGetSettings: "{{ url_for('get_settings') }}",
+            apiSaveSettings: "{{ url_for('settings_api.save_settings') }}",
+            apiGetSettings: "{{ url_for('settings_api.get_settings') }}",
             apiImportRoute: "{{ url_for('route_api.import_route') }}"
         };
     </script>


### PR DESCRIPTION
# PR: Fix Flask Route Endpoints for Settings

## Summary

This PR aims to fix the issue caused by the URLs used to fetch settings data from the backend, as they remained as such even after the implementation of the `settings_api_bp`, the settings Flask Blueprint introduced in PR #23 which prevented core features such as the in-app theme as well as the changing of distance units. This bug also prevented the viewing of the map because it returned an error whilst retrieving settings. 