### PR TITLE
Fix: dark mode coord entries

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -259,6 +259,7 @@ body {
     background: white;
     color: #1e293b;
     width: 180px;
+    transition: all 0.14s ease-in-out
 }
 
 .coord-input:hover {
@@ -1094,6 +1095,26 @@ html.dark .coord-input {
     background: #374151;
     color: #f3f4f6;
     border-color: #4b5563;
+}
+
+html.dark .coord-input:focus {
+    border-color: #3b82f6; 
+    box-shadow: 0 0 4px 1px rgba(59, 130, 246, 0.2),
+                0 0 12px 4px rgba(59, 130, 246, 0.1);
+    outline: none;
+}
+
+html.dark .coord-input.is-active {
+    border-color: #3b82f6; 
+    box-shadow: 0 0 4px 1px rgba(59, 130, 246, 0.2),
+                0 0 12px 4px rgba(59, 130, 246, 0.1);
+    outline: none;
+}
+
+/* This overrides the white autofill background for dark mode */
+html.dark input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0px 1000px #374151 inset !important; 
+    -webkit-text-fill-color: #f3f4f6 !important;
 }
 
 html.dark .coord-input::placeholder {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -713,10 +713,19 @@ export function homeButtonFunction() {
   const map = getMap();
   if (!map) return;
 
-  endCoordEntry?.classList.remove("input-error");
-  startCoordEntry?.classList.remove("input-error");
-  if (startCoordEntry) startCoordEntry.placeholder = "Coordinates";
-  if (endCoordEntry) endCoordEntry.placeholder = "Coordinates";
+  if (startCoordEntry) {
+    startCoordEntry.classList.remove('input-error');
+    startCoordEntry.classList.remove('is-active');
+    startCoordEntry.placeholder = "Coordinates";
+  }
+
+  if (endCoordEntry) {
+    endCoordEntry.classList.remove('input-error');
+    endCoordEntry.classList.remove('is-active');
+    endCoordEntry.placeholder = "Coordinates";
+  }
+
+  clickMode = null;
   generatePathButton?.classList.remove("loading");
 
   clearManualRoute();
@@ -759,6 +768,7 @@ export function homeButtonFunction() {
 //#endregion
 
 function searchArea() {
+  if (searchEntry) searchEntry.value = "";
   const map = getMap();
   if (!map) return;
 
@@ -770,6 +780,7 @@ function searchArea() {
     .then((response) => response.json())
     .then((data) => {
       if (!data.success) return;
+
       const view = map.getView();
       if (view.getZoom() >= 7) {
         view.animate(
@@ -789,7 +800,7 @@ function searchArea() {
         });
       }
     })
-    .catch((error) => console.log("Error: ", error));
+    .catch((error) => showError("There was an unexpected error, please try again later."));
 };
 
 async function mapRenderComplete() {


### PR DESCRIPTION
# Summary
Updated dark mode coordinate inputs to improve focus and active states.
# Changes
- Added a blue border and glow effect to .coord-input on focus and active states.
- Removed default browser focus outlines.
- Synced styling across :focus and .is-active states.