### PR TITLE
chore: fix save route panel hover styling in dark mode

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -661,6 +661,13 @@ html.dark #save-route-toggle-button {
     color: #f3f4f6;
 }
 
+html.dark #save-route-toggle-button:hover + #save-route,
+html.dark #save-route-toggle-button:hover {
+    background: rgba(18, 25, 34, 0.75);
+    color: #f3f4f6;
+}
+
+
 html.dark .coords-header,
 html.dark .stats-header {
     background: rgb(55 65 81 / 0.75);


### PR DESCRIPTION
# PR: Fix dark mode hover styling for save route toggle and panel

# Description

Previously, hovering over the save route panel in dark mode caused the toggle button to lose its hover state and the panel to appear white.

# Changes

- Added specific dark mode hover rules for #save-route-toggle-button and #save-route

This ensures consistent dark appearance on hover.