### PR TITLE
fix: Resolve elevation formatting in creation of saved route cards

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -82,12 +82,12 @@ app.config.update(
 @app.template_filter('format_elevation')
 def format_elevation(elevation_gain):
     if not isinstance(elevation_gain, int) or isinstance(elevation_gain, float):
-        elevation_gain = float(elevation_gain)
+        elevation_gain = int(float(elevation_gain))
 
     if elevation_gain >= 0:
-        return f"+{elevation_gain}"
+        return f"+{elevation_gain}m"
     else:
-        return f"{elevation_gain}"
+        return f"{elevation_gain}m"
 
 @app.template_filter('format_eta')
 def format_eta(seconds):

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -178,7 +178,7 @@ export function removeDOMElement(element) {
  * @returns {string} this is a string which has been formated to add a + or leave the string unchanged if it is negative 
  */
 export function formatElevation(elevationChange) {
-  const elevNum = isNaN(elevationChange) ? parseFloat(elevationChange) : elevationChange;
+  const elevNum = isNaN(elevationChange) ? parseInt(elevationChange) : elevationChange;
   const elevDisplayValue = isNaN(elevNum) ? "0m" : (elevNum >= 0 ? `+${elevNum}m` : `${elevNum}m`)
 
   return elevDisplayValue


### PR DESCRIPTION
# PR: Fix elevation display - convert to integer and add metres unit

# Description
Elevation was previously displayed as a float with no units. This change improves readability.

# Changes

- **Backend**: Converted elevation to integer and appended 'm' unit
- **Frontend**: Updated display logic to handle integer elevation value

Elevation now shows as clean whole numbers with proper "m" suffix (e.g. "245m").