### PR TITLE
feat: Add umami analytics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 services:
+
+  # POSTGRES DATABASE 
   db:
     image: postgres:16-alpine
     env_file:
@@ -15,6 +17,8 @@ services:
       retries: 10
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  # MAIN APP
   web:
     build: .
     command: gunicorn -c src/gunicorn.config.py src.app:app ### Use this command for prod 
@@ -41,7 +45,7 @@ services:
       # - LOAD_GRAPH_ON_IMPORT=0    # 0 stops graph loading on import for fast hot-reloads
       # - FLASK_ENV=development
     ports:
-      - "5000:5000"
+      - "5000:5000" # Local access: http://localhost:5000
     env_file:
       - path: example.env
         required: true
@@ -50,6 +54,45 @@ services:
     depends_on:
       db:
         condition: service_healthy
+  
+  # UMAMI ANALYTICS 
+  umami-db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: ${UMAMI_DB_PASSWORD}
+    volumes:
+      - umami_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U umami -d umami"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"   # Local access: http://localhost:3000
+    environment:
+      DATABASE_URL: postgresql://umami:${UMAMI_DB_PASSWORD}@umami-db:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+      # Optional: uncomment these to make tracking harder to block (for self hosters + prod)
+      # COLLECT_API_ENDPOINT: /api/collect
+      # TRACKER_SCRIPT_NAME: analytics.js
+    depends_on:
+      umami-db:
+        condition: service_healthy
+    # Healthcheck is commented out for now (see explanation below)
+    # healthcheck:
+    #   test: ["CMD-SHELL", "curl -f http://localhost:3000/api/heartbeat || exit 1"]
+    #   interval: 30s
+    #   timeout: 10s
+    #   retries: 3
+  
+  # PGADMIN 
   pgadmin:
     image: dpage/pgadmin4:latest
     container_name: crestr-pgadmin
@@ -61,7 +104,7 @@ services:
       PGADMIN_CONFIG_SERVER_MODE: '${PGADMIN_SERVER_MODE}'
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: '${PGADMIN_MASTER_REQ}'
     ports:
-      - "${PGADMIN_PORT}:80"
+      - "${PGADMIN_PORT}:80" # Local access: http://localhost:5050 (configured via .env file)
     depends_on:
       db:
         condition: service_healthy
@@ -70,3 +113,4 @@ services:
 volumes:
   postgres_data:
   pgadmin_data:
+  umami_postgres_data:

--- a/example.env
+++ b/example.env
@@ -19,3 +19,17 @@ PGADMIN_PORT=5050
 # Database Connection URIs
 DATABASE_URI=postgresql://crestr_dev:secure_hiking_pass_2025@db:5432/crestr_hiking
 LOCAL_DATABASE_URI=postgresql://crestr_dev:secure_hiking_pass_2025@localhost:5432/crestr_hiking
+
+# Umami (analytics)
+
+# Specific Website ID provided by Umami
+UMAMI_WEBSITE_ID = get_ID_from_umami
+
+# Umami script.js url, defaults to localhost:3000
+UMAMI_SCRIPT_URL = http://localhost:3000/script.js
+
+# Umami Database
+UMAMI_DB_PASSWORD=change_this_to_a_strong_password
+
+# Umami Application Secret (generate a strong one)
+UMAMI_APP_SECRET=your_very_long_random_secret_here

--- a/src/app.py
+++ b/src/app.py
@@ -53,6 +53,7 @@ app.register_blueprint(auth_api_bp)
 app.register_blueprint(settings_api_bp)
 
 # Configuration Keys
+app.config.from_object(Config)
 app.secret_key = Config.SECRET_KEY
 locationiq_api_key = Config.LOCATIONIQ_API_KEY
 app.config["SQLALCHEMY_DATABASE_URI"] = Config.DATABASE_URI
@@ -283,6 +284,10 @@ def search_area():
 
 #endregion
 
+# This makes config available in Jinja templates
+@app.context_processor
+def inject_config():
+    return {"config": app.config}
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/src/config.py
+++ b/src/config.py
@@ -17,3 +17,5 @@ class Config:
     DATABASE_URI = os.getenv('DATABASE_URI')
     LOCAL_DATABASE_URI = os.getenv('LOCAL_DATABASE_URI')
     GRAPH_PATH = os.getenv('GRAPH_PATH')
+    UMAMI_WEBSITE_ID = os.getenv('UMAMI_WEBSITE_ID')
+    UMAMI_SCRIPT_URL = os.getenv('UMAMI_SCRIPT_URL')

--- a/templates/map.html
+++ b/templates/map.html
@@ -44,6 +44,17 @@
     
     <!-- Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+    <!-- Umami Analytics -->
+    <!-- SELF HOSTERS: Change values in you .env file -->
+    <!-- Umami Analytics -->
+    {% if config.UMAMI_WEBSITE_ID %}
+    <script async defer 
+            src="{{ config.UMAMI_SCRIPT_URL }}" 
+            data-website-id="{{ config.UMAMI_WEBSITE_ID }}">
+    </script>
+    {% endif %}
+
 </head>
 <body>
 


### PR DESCRIPTION
# PR: Add Umami Analytics via Docker Compose

# Description:

Added Umami Analytics as a self-hosted service for website analytics tracking.

# Changes:

- Added Umami service definition to `docker-compose.yml`
- Configured necessary environment variables and networking for Umami
- Included database setup for the analytics instance

This enables privacy-friendly analytics without relying on external third-party services.