### PR TITLE
fix(frontend): Amend frontend elevation (and distance) displaying 

### DIFF
--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -1,4 +1,4 @@
-import { showError, addClickListener, createRouteCard, calculateEta, formatDistance, formatETA } from "./utils.js";
+import { showError, addClickListener, createRouteCard, calculateEta, formatDistance, formatETA, formatElevation } from "./utils.js";
 
 const allRoutesContainer = document.getElementById("all-routes-container");
 
@@ -41,7 +41,7 @@ export function displayImportedRouteCard(data) {
 
     const formattedETA = formatETA(routeInfo.eta_seconds);
 
-    const routeCard = createRouteCard(routeInfo.route_name, formattedToday, routeInfo.distance_km, formattedETA, routeInfo.elevation_gain_metres);
+    const routeCard = createRouteCard(routeInfo.route_name, formattedToday, routeInfo.distance_km, formattedETA, formatElevation(routeInfo.elevation_gain_metres));
 
     if (allRoutesContainer) allRoutesContainer.insertAdjacentHTML("beforeend", routeCard);            
 }

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -1,5 +1,5 @@
 import { getMap, getRouteLayer, getPathColour } from "../map.js";
-import { formatDistance, getRouteStrokeStyle, createManualPointStyle, formatETA } from "../utils.js";
+import { formatDistance, getRouteStrokeStyle, createManualPointStyle, formatETA, createStatsPanel, formatElevation } from "../utils.js";
 import { clearLastLoadedRouteStats, getLastLoadedRouteStats, setCurrentPathData, setLastKnownDistanceKm, setLastLoadedRouteStats, setLoadedRouteCoordinates } from "./routeState.js";
 import { deleteRoute, loadRoute } from "./routeApi.js";
 
@@ -104,37 +104,15 @@ export function displayLoadedRouteStats(routeStats) {
 
   setLastKnownDistanceKm(routeStats.total_distance);
 
-  const statsHtml = `
-    <div id="route-stats">
-      <div class="stats-header">
-          <span class="stats-title">Route Information</span>
-          <button id="toggle-elevation-chart" class="stats-button">Elevation Profile</button>
-      </div>
-      <div id="stat-content-and-chart-container">
-          <div class="stats-content">
-              <div class="stat-row">
-                  <span class="stat-label">Distance:</span>
-                  <span class="stat-value" id="route-distance-display">${formatDistance(parseFloat(routeStats.total_distance))}</span>
-              </div>
-              <div class="stat-row">
-                  <span class="stat-label">ETA:</span>
-                  <span class="stat-value" id="route-eta-display">${formatETA(routeStats.eta_seconds)}</span>
-              </div>
-              <div class="stat-row">
-                  <span class="stat-label">Elevation Change:</span>
-                  <span class="stat-value" id="route-elevation-change-display">${routeStats.elevation_change}</span>
-              </div>
-          </div>
+  let statsDiv = document.getElementById("route-stats");
 
-          <div class="chart-wrapper"> 
-              <div id="elevation-chart-container">
-                  <canvas id="elevation-chart"></canvas>
-              </div>
-          </div>
-      </div>
-    </div>
-  `;
-  const existingStats = document.getElementById("route-stats");
-  if (existingStats) existingStats.remove();
-  document.body.insertAdjacentHTML("beforeend", statsHtml);
+  if (statsDiv) {
+    statsDiv.remove
+  };
+
+  statsDiv = document.createElement("div");
+  statsDiv.id = "route-stats";
+  document.body.appendChild(statsDiv);
+
+  statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), formatETA(routeStats.eta_seconds), formatElevation(routeStats.elevation_change))
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -767,6 +767,7 @@ export function homeButtonFunction() {
 
 //#endregion
 
+//#region SEARCHING FUNCTION
 function searchArea() {
   if (searchEntry) searchEntry.value = "";
   const map = getMap();
@@ -802,6 +803,7 @@ function searchArea() {
     })
     .catch((error) => showError("There was an unexpected error, please try again later."));
 };
+//#endregion
 
 async function mapRenderComplete() {
 
@@ -910,6 +912,10 @@ function displayPath(data) {
 function displayAutoRouteStats(routeStats) {
 
   let statsDiv = document.getElementById("route-stats");
+
+  if (statsDiv) {
+    statsDiv.remove
+  };
 
   statsDiv = document.createElement("div");
   statsDiv.id = "route-stats";

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -72,9 +72,9 @@ export function formatDistance(distanceKm) {
 
   if (distanceUnit === "miles") {
     const distanceMiles = distanceKm * 0.621371; 
-    return `${distanceMiles.toFixed(2)}mi`;
+    return `${distanceMiles.toFixed(2)} mi`;
   }
-  return `${distanceKm.toFixed(2)}km`;
+  return `${distanceKm.toFixed(2)} km`;
 }
 
 export function calculateTotalDistance(points) {
@@ -177,9 +177,9 @@ export function removeDOMElement(element) {
  * @param {string|number} elevationChange usually this is a string such as "938.0" or "-329.0" however the possibility of an int / float being passed is accounted for
  * @returns {string} this is a string which has been formated to add a + or leave the string unchanged if it is negative 
  */
-export function formatElevation(elevationChange) {
-  const elevNum = isNaN(elevationChange) ? parseInt(elevationChange) : elevationChange;
-  const elevDisplayValue = isNaN(elevNum) ? "0m" : (elevNum >= 0 ? `+${elevNum}m` : `${elevNum}m`)
+export function formatElevation(elevation) {
+  const elevNum = Math.round(Number(elevation))
+  const elevDisplayValue = isNaN(elevNum) ? "0m" : (elevNum >= 0 ? `+${elevNum} m` : `${elevNum} m`)
 
   return elevDisplayValue
 }


### PR DESCRIPTION
# PR: Align frontend elevation display with backend formatting

# Description:

Updated the frontend to properly display elevation values in line with the backend changes (integer format with metres unit).

# Changes:

- Modified elevation display logic on the frontend
- Ensured consistent formatting between backend and frontend (e.g. "245 m")

This resolves previous discrepancies where elevation appeared as a float without units when loading saved routes.