### PR TITLE
fix: Amend displaying of route stats so that the stats panel is remov…

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -195,9 +195,10 @@ body {
 }
 
 .coord-input:focus {
+    border-color: #3b82f6; 
+    box-shadow: 0 0 4px 1px rgba(59, 130, 246, 0.2),
+                0 0 12px 4px rgba(59, 130, 246, 0.1);
     outline: none;
-    border-color: #2563eb;
-    box-shadow: 0 0 0 0.2px rgba(37, 99, 235, 0.1);
 }
 
 .input-error {

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -2,6 +2,7 @@ import { getMap, getRouteLayer, getPathColour } from "../map.js";
 import { formatDistance, getRouteStrokeStyle, createManualPointStyle, formatETA, createStatsPanel, formatElevation } from "../utils.js";
 import { clearLastLoadedRouteStats, getLastLoadedRouteStats, setCurrentPathData, setLastKnownDistanceKm, setLastLoadedRouteStats, setLoadedRouteCoordinates } from "./routeState.js";
 import { deleteRoute, loadRoute } from "./routeApi.js";
+import { initChartToggleListener } from "../elevationChart.js";
 
 
 let routeList = null;
@@ -107,7 +108,7 @@ export function displayLoadedRouteStats(routeStats) {
   let statsDiv = document.getElementById("route-stats");
 
   if (statsDiv) {
-    statsDiv.remove
+    statsDiv.remove();
   };
 
   statsDiv = document.createElement("div");

--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -8,7 +8,7 @@ import { closeNav, closeSavedRoutesDash,  } from "../ui.js"
 import { displayLoadedRouteOnMap } from "./loadRoute.js";
 import { setLoadedRouteCoordinates, setCurrentPathData } from "./routeState.js";
 import { createElevationProfile, initChartToggleListener } from "../elevationChart.js";
-import {addClickListener, createNoRouteCard} from "../utils.js"
+import {addClickListener, createNoRouteCard, formatDistance} from "../utils.js"
 
 const allRoutesContainer = document.getElementById("all-routes-container");
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -914,7 +914,7 @@ function displayAutoRouteStats(routeStats) {
   let statsDiv = document.getElementById("route-stats");
 
   if (statsDiv) {
-    statsDiv.remove
+    statsDiv.remove();
   };
 
   statsDiv = document.createElement("div");
@@ -1236,15 +1236,19 @@ export function applyTheme(theme) {
 // ##### HANDLING TOGGLING OF DISTANCE UNITS #####
 function handleDistanceUnitToggle() {
 
+  resetElevationChart();
+
   // if there is a manual route present
   if (manualRouteState.pathCoords.length > 0) {
     updateManualRoute();
   }
   else if (getLastAutoRouteStats()) {
     displayAutoRouteStats(getLastAutoRouteStats());
+    toggleElevationChart();
   }
   else if (getLastLoadedRouteStats) {
     displayLoadedRouteStats(getLastLoadedRouteStats());
+    toggleElevationChart();
   }
   initChartToggleListener();
 


### PR DESCRIPTION
# PR: Fix elevation profile stats panel overlap for loaded and auto-created routes

# Description:

Resolved an issue where the elevation stats panel was being stacked on top of an existing one when loading saved routes or generating automatic routes. This caused the elevation profile button to become unresponsive.

# Changes:

- Added conditional logic to remove any existing stats panel before creating a new one
- Applied fix specifically for loaded routes and automatically created routes (manual routing remains unchanged)

This ensures clean panel management and reliable elevation profile functionality.