### PR TITLE
chore: Add tooltip and remove functionality for URL route import radi…

### DIFF
--- a/static/css/settings_panel.css
+++ b/static/css/settings_panel.css
@@ -373,6 +373,73 @@
     font-weight: 700;
 }
 
+/* Tooltip support for unavailable styling (can be used elsewhere e.g in import route panel) */
+
+/* Tooltip wrapper */
+.radio-pill[data-tooltip] {
+    position: relative;
+}
+
+.radio-pill[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%) translateY(4px);
+    background: #1f2937;
+    color: #fff;
+    font-size: 12px;
+    line-height: 1.3;
+    white-space: normal;
+    width: max-content;
+    max-width: 15rem;
+    padding: 6px 10px;
+    border-radius: 6px;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 20;
+}
+
+/* Little arrow */
+.radio-pill[data-tooltip]::before {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%) translateY(4px);
+    border: 5px solid transparent;
+    border-top-color: #1f2937;
+    margin-bottom: -2px;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 20;
+}
+
+.radio-pill[data-tooltip]:hover::after,
+.radio-pill[data-tooltip]:hover::before {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* Disabled pill styling */
+.radio-pill.disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.radio-pill.disabled input {
+    cursor: not-allowed;
+}
+
+.radio-pill.disabled span {
+    pointer-events: none;
+}
+
 /* Range slider wrapper + styling */
 .settings-range-wrapper {
     display: flex;

--- a/templates/map.html
+++ b/templates/map.html
@@ -374,14 +374,14 @@
                         <span class="import-route-item-description">Choose how you want to load your route</span>
                     </div>
 
-                    <div class="settings-radio-pills">
+                    <div id="file-route-input-pill" class="settings-radio-pills">
                         <label class="radio-pill">
                             <input id="file-route-input-type" type="radio" name="import-route-method" value="file" checked>
                             <span>File</span>
                         </label>
 
-                        <label class="radio-pill">
-                            <input id="url-route-input-type" type="radio" name="import-route-method" value="url">
+                        <label id="url-route-input-pill" class="radio-pill disabled" data-tooltip="URL import is currently disabled. Please use the file upload option.">
+                            <input id="url-route-input-type" type="radio" name="import-route-method" value="url" disabled>
                             <span>URL</span>
                         </label>
                     </div>


### PR DESCRIPTION
# PR Title: Add tooltip for disabled URL import option ahead of beta launch

# Summary

As we approach beta, the URL route import option isn't ready for use yet. This PR adds a tooltip to the pill so users understand why it's disabled, rather than leaving them to guess or file a bug report.

# What Changed

- Disabled the URL import radio pill and input
- Added a hover tooltip explaining the feature isn't available during beta
- Styled the pill to visually indicate it's inactive (reduced opacity, disabled cursor)