### PR TITLE
chore: Add privacy policy links 

### DIFF
--- a/static/css/login_page.css
+++ b/static/css/login_page.css
@@ -154,3 +154,22 @@
     top: 20px;
     left: 20px;
 }
+
+#register-privacy-notice {
+    font-size: 0.75rem;
+    color: #777;
+    text-align: center;
+    width: 17rem;
+    align-self: center;
+    line-height: 1.4;
+    padding: 0px;
+}
+
+#register-privacy-notice a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+#register-privacy-notice a:hover {
+    text-decoration: underline;
+}

--- a/static/css/register_page.css
+++ b/static/css/register_page.css
@@ -138,3 +138,24 @@
     color: #ff4d4d; /* red */
     opacity: 1;
 }
+
+/* Privacy Policy */
+
+#register-privacy-notice {
+    font-size: 0.75rem;
+    color: #777;
+    text-align: center;
+    width: 17rem;
+    align-self: center;
+    line-height: 1.4;
+    padding: 0px;
+}
+
+#register-privacy-notice a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+#register-privacy-notice a:hover {
+    text-decoration: underline;
+}

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -43,15 +43,11 @@ function createMap() {
   map = new ol.Map({
     layers: [tileLayer],
     target: "map",
-    controls: new ol.control.defaults
-      .defaults({
-        attribution: false,
-      })
-      .extend([
-        new ol.control.Attribution({
-          collapsible: false,
-        }),
-      ]),
+    controls: ol.control.defaults.defaults({
+      attributionOptions: {
+        collapsible: false
+      }
+    }),
     view: new ol.View({
       projection: "EPSG:3857",
       maxZoom: 17,
@@ -78,10 +74,14 @@ export function createTileLayer() {
   tileLayer = new ol.layer.Tile({
     source: new ol.source.XYZ({
       url: "https://{a-c}.tile.opentopomap.org/{z}/{x}/{y}.png",
-      attributions: `Map data: © <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap</a>,
+      attributions: `
+      <a href="https://docs.crestr.co.uk/privacy-policy/privacy_policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+      |
+      Map data: © <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap</a>,
       SRTM
       |
-      Map style: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)`,
+      Map style: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)
+      `,
       maxZoom: 17,
     }),
   });

--- a/templates/login.html
+++ b/templates/login.html
@@ -20,7 +20,13 @@
                 <label class="inner-entry-label" for="login_password_entry">Password</label>
                 <i class="fa-solid fa-eye"></i>
             </div>
+
             <button id="login_button" class="auth-button">Login</button>
+
+            <p id="login-privacy-notice">
+                By logging in, you agree to our
+                <a href="https://docs.crestr.co.uk/privacy-policy/privacy_policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+            </p>
         </div>
         <div id="switch_to_register_container">
             <label for="switch_to_register_button" id="switch_to_register_lable">Don't have an account ? Register below</label>

--- a/templates/register.html
+++ b/templates/register.html
@@ -50,6 +50,11 @@
             </div>
 
             <button id="register-button" class="auth-button">Register</button>
+
+            <p id="register-privacy-notice">
+                By registering, you agree to our
+                <a href="https://docs.crestr.co.uk/privacy-policy/privacy_policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+            </p>
         </div>
 
         <div id="register_go_back_button_container">


### PR DESCRIPTION
# PR Title: Add privacy policy link to Registration, Login and Map page

# Summary

Registration (and other mentioned actions) didn't previously surface a link to the privacy policy, which we need in place ahead of beta for ICO compliance. 
This PR adds a clear, accessible link on the register screen.

# What Changed

- Added a privacy policy notice above the register button, linking to docs.crestr.co.uk
- Link opens in a new tab so users don't lose their in-progress registration
- Styled to match the existing form's sizing and colour scheme