### PR TITLE
feat: Add dark mode to report-issue page

### DIFF
--- a/static/css/report-issue.css
+++ b/static/css/report-issue.css
@@ -1,16 +1,27 @@
-
 :root {
+
+  /* Constant colours */
+  --error: #dc2626;
+  --ok: #16a34a;
+
+  /* Theme variables (Light Mode defaults) */
   --blue: #2563eb;
   --blue-dark: #1d4ed8;
   --blue-soft: rgba(37, 99, 235, 0.08);
   --blue-ring: rgba(37, 99, 235, 0.28);
 
+  --bg: #ffffff;
+  --surface-bg: rgba(255, 255, 255, 0.92);
+  --field-bg: #ffffff;
   --ink: #1f2937;
   --muted: #64748b;
+  --placeholder: #94a3b8;
   --border: #e2e8f0;
-  --error: #dc2626;
-  --ok: #16a34a;
+  
+  --btn-disabled-bg: #93b4f2;
+  --btn-disabled-text: #ffffff;
 
+  /* Layout and shapes */
   --radius-lg: 20px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -22,24 +33,48 @@
     "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-body {
-  background: #ffffff;
-  font-family: var(--font-sans);
-  color: var(--ink);
+/* DARK MODE */
+html.dark {
+  --bg: #0f172a;
+  --surface-bg: rgba(30, 41, 59, 0.8);
+  --field-bg: #1e293b;
+  --ink: #f8fafc;
+  --muted: #94a3b8;
+  --placeholder: #64748b;
+  --border: #334155;
+
+  /* Slightly brighter blues for better contrast in dark mode */
+  --blue: #3b82f6; 
+  --blue-dark: #60a5fa;
+  --blue-soft: rgba(59, 130, 246, 0.15);
+  --blue-ring: rgba(59, 130, 246, 0.4);
+
+  --btn-disabled-bg: #1e293b;
+  --btn-disabled-text: #64748b;
+
+  --shadow-surface: 0 10px 35px rgba(0, 0, 0, 0.3);
+  --shadow-lift: 0 4px 12px rgba(59, 130, 246, 0.2);
 }
 
+/* Base Styles */
+body {
+  background: var(--bg);
+  font-family: var(--font-sans);
+  color: var(--ink);
+  transition: background-color 0.3s ease, color 0.3s ease; 
+}
 
 .surface {
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--surface-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-surface);
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 /* Buttons */
-
 .btn {
   display: inline-flex;
   align-items: center;
@@ -83,7 +118,8 @@ body {
 }
 
 .btn-primary:disabled {
-  background: #93b4f2;
+  background: var(--btn-disabled-bg);
+  color: var(--btn-disabled-text);
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
@@ -114,7 +150,6 @@ body {
 }
 
 /* Form fields */
-
 .field {
   display: flex;
   flex-direction: column;
@@ -133,11 +168,13 @@ body {
   font-size: 0.95rem;
   line-height: 1.45;
   color: var(--ink);
-  background: #fff;
+  background: var(--field-bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 0.75rem 0.85rem;
-  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: box-shadow 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+              border 0.15s cubic-bezier(0.4, 0, 0.2, 1)
+              ;
 }
 
 .field-textarea {
@@ -147,20 +184,18 @@ body {
 
 .field-input::placeholder,
 .field-textarea::placeholder {
-  color: #94a3b8;
+  color: var(--placeholder);
 }
 
 .field-input:focus,
 .field-textarea:focus {
-  border-color: #3b82f6; 
-    box-shadow: 0 0 4px 1px rgba(59, 130, 246, 0.2),
-                0 0 12px 4px rgba(59, 130, 246, 0.1);
-    outline: none;
+  border-color: var(--blue); 
+  box-shadow: 0 0 4px 1px var(--blue-soft),
+              0 0 12px 4px var(--blue-ring);
+  outline: none;
 }
 
-
 /* Navbar */
-
 #navbar {
   display: flex;
   align-items: center;
@@ -229,8 +264,35 @@ body {
   }
 }
 
-/* Report Issue page inputs */
+/* Theme Toggle */
+#theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  color: var(--muted);
+}
 
+#theme-toggle:hover {
+  background: var(--blue-soft);
+  color: var(--blue);
+}
+
+/* Default state: show moon, hide sun */
+#theme-toggle .icon-sun {
+  display: none;
+}
+
+#theme-toggle .icon-moon {
+  color: #1a2030;
+  display: block;
+}
+
+/* Report Issue page inputs */
 #report-issue-container {
   max-width: 480px;
   margin: 3rem auto;
@@ -277,4 +339,25 @@ body {
   .field-textarea {
     transition: none;
   }
+  body, .surface {
+    transition: none;
+  }
+}
+
+/* DARK MODE */ 
+
+/* Crestr logo (dark mode) */
+html.dark #navbar-logo-image {
+  filter: brightness(0) invert(0.8);
+}
+
+/* light/dark theme toggle */
+
+html.dark #theme-toggle .icon-sun {
+  display: block;
+  color: #f59e0b;
+}
+
+html.dark #theme-toggle .icon-moon {
+  display: none;
 }

--- a/static/js/report-issue.js
+++ b/static/js/report-issue.js
@@ -7,6 +7,55 @@ const titleInput = document.getElementById("issue-title");
 const textarea = document.getElementById("issue-description");
 const submitButton = document.getElementById("submit-button");
 
+// DARK MODE 
+
+// Helper to apply the class to the document
+function setDarkMode(isDark){
+    if (isDark) {
+        document.documentElement.classList.add("dark");
+    } else {
+        document.documentElement.classList.remove("dark");
+    }
+};
+
+function onThemeToggleClick() {
+    const isCurrentlyDark = document.documentElement.classList.contains("dark");
+    const newThemeState = !isCurrentlyDark;
+    
+    setDarkMode(newThemeState);
+    
+    localStorage.setItem("user-theme", newThemeState ? "dark" : "light");
+}
+
+function initDarkMode() {
+    const themeToggle = document.getElementById("theme-toggle");
+    const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    // This determines the initial state 
+    const savedTheme = localStorage.getItem("user-theme");
+    
+    if (savedTheme) {
+        // This ensure that if a user has explicitly chosen a setting before, use it
+        setDarkMode(savedTheme === "dark");
+    } else {
+        // Otherwise, it'll fall back to the OS system preference
+        setDarkMode(darkModeQuery.matches);
+    }
+
+    if (themeToggle) {
+        themeToggle.addEventListener("click", onThemeToggleClick);
+    }
+
+    // This runs if the user hasn't overridden preferences
+    darkModeQuery.addEventListener("change", (e) => {
+        if (!localStorage.getItem("user-theme")) {
+            setDarkMode(e.matches);
+        }
+    });
+}
+
+initDarkMode();
+
 /**
  * This function validates the input fields for the report issue form.
  * @param {string} title 

--- a/templates/report-issue.html
+++ b/templates/report-issue.html
@@ -17,14 +17,26 @@
     <nav id="navbar" class="surface">
         <div id="left-nav-side" class="nav-sides">
             <div id="navbar-logo-container">
-                <a href="https://crestr.co.uk">
+                <a href="https://crestr.co.uk" aria-label="Link to go to main landing page">
                     <img src="https://images.crestr.co.uk/Crest-Logo.png" id="navbar-logo-image" alt="Crest logo">
                 </a>
             </div>
         </div>
 
         <div id="right-nav-side" class="nav-sides">
-            <a href="javascript:history.back()" id="back-button" class="btn btn-ghost">
+            <button id="theme-toggle" class="btn btn-ghost" aria-label="Toggle dark mode">
+
+                <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+                </svg>
+
+                <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="4"/>
+                    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+                </svg>
+            </button>
+
+            <a href="javascript:history.back()" id="back-button" class="btn btn-ghost" aria-label="Link to go back to previous page">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <path d="M15 18l-6-6 6-6"/>
                 </svg>
@@ -40,15 +52,15 @@
             <h1>Report an Issue</h1>
                 <div class="field">
                     <label for="issue-title" class="field-label">Title</label>
-                    <input type="text" id="issue-title" name="issue-title" class="field-input" placeholder="A short summary of the issue" required>
+                    <input type="text" id="issue-title" name="issue-title" class="field-input" aria-label="Input to add issue title" placeholder="A short summary of the issue" required>
                 </div>
 
                 <div class="field">
                     <label for="issue-description" class="field-label">Describe the issue</label>
-                    <textarea id="issue-description" name="issue-description" class="field-textarea" rows="5" placeholder="What happened? What did you expect instead?" required></textarea>
+                    <textarea id="issue-description" name="issue-description" class="field-textarea" aria-label="Input to add issue description" rows="5" placeholder="What happened? What did you expect instead?" required></textarea>
                 </div>
 
-                <button id="submit-button" class="btn btn-primary">Submit</button>
+                <button id="submit-button" class="btn btn-primary" aria-label="button to submit issue" >Submit</button>
             <div id="response-message"></div>
         </div>
 </div>


### PR DESCRIPTION
# PR: Automated & Interactive Dark Mode Toggle for the Report Issues page

## Summary
Introduces a robust, responsive dark mode solution that supports both automatic OS-level theme preference tracking and manual user overrides. Manual selections are saved in `localStorage` to persist across pages and reloads, while a new sun / moon toggle button is added to the main navigation bar.

## What changed
* **HTML (`report-issue.html`)**: Added a clickable `#theme-toggle` button in the navigation header containing dynamic SVGs for light/dark modes, positioned neatly to the left of the "Back" button.
* **JavaScript (`report-issue.js`)**: Created a smart theme initialisation system (`initDarkMode()`) that handles OS preference changes via the `matchMedia` API, implements the manual override click event handler, and manages state persistence using `localStorage`.
* **CSS (`report-issue.css`)**: Refactored static color values to CSS variables under `:root` and added overrides under the `html.dark` selector. Created style rules for the theme toggle button and added transition effects to allow smooth fading between light and dark backgrounds.